### PR TITLE
Move package to 3dbionotes organisation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "pdbe-molstar",
-  "version": "1.1.0-dev.4",
+  "name": "@3dbionotes/pdbe-molstar",
+  "version": "1.1.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "pdbe-molstar",
-  "version": "1.1.0",
+  "name": "@3dbionotes/pdbe-molstar",
+  "version": "1.1.0-beta.1",
   "description": "Molstar implementation for PDBe",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Required by https://app.clickup.com/t/d52gh5

For now, only required because we needed to publish the master branch. 

If, on the future, we can simply use the exported react components without changes, we will  delete this and point upstream. Otherwise, we'll keep this package with upstream merging.