### PR TITLE
Changes required by selectors 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@3dbionotes/pdbe-molstar",
-  "version": "1.1.0-beta.1",
+  "version": "1.1.0-beta.2",
   "description": "Molstar implementation for PDBe",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@3dbionotes/pdbe-molstar",
-  "version": "1.1.0-beta.2",
+  "version": "1.1.0-beta.3",
   "description": "Molstar implementation for PDBe",
   "main": "index.js",
   "scripts": {

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -623,4 +623,7 @@ class PDBeMolstarPlugin {
     }
 }
 
+export { PDBeMolstarPlugin }
+
+
 (window as any).PDBeMolstarPlugin = PDBeMolstarPlugin;

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -570,6 +570,20 @@ class PDBeMolstarPlugin {
             }
 
         },
+        setVisibility: (label: string, visible: boolean) => {
+            this.getCellsByLabel(label).forEach(({ ref, state }) => {
+                const isCurrentlyVisible = !state || !state.isHidden;
+
+                if (visible !== isCurrentlyVisible) {
+                    PluginCommands.State.ToggleVisibility(this.plugin, { state: this.state, ref  });
+                }
+            })
+        },
+        remove: (label: string) => {
+            this.getCellsByLabel(label).forEach(({ ref }) => {
+                PluginCommands.State.RemoveObject(this.plugin, { state: this.state, ref });
+            })
+        },
         toggleSpin: (isSpinning?: boolean, resetCamera?: boolean) => {
             if (!this.plugin.canvas3d) return;
             const trackball =  this.plugin.canvas3d.props.trackball;
@@ -612,6 +626,15 @@ class PDBeMolstarPlugin {
             }
 
         }
+    }
+
+    private getCellsByLabel(label: string): Array<{ ref: string; state: StateTransform.State; }> {
+        return Array.from(this.plugin.state.data.cells)
+            .map(([ref, cell]) => ({ ref, cell }))
+            .filter(({ cell }) => cell.obj?.label === label)
+            .map(({ ref }) => ({ ref, compVisual: this.plugin.state.data.select(ref)[0] }))
+            .filter(({ compVisual }) => compVisual && compVisual.obj)
+            .map(({ ref, compVisual }) => ({ ref, state: compVisual.state }));
     }
 
     async clear() {

--- a/src/app/ui/pdbe-left-panel.tsx
+++ b/src/app/ui/pdbe-left-panel.tsx
@@ -82,7 +82,7 @@ export class LeftPanelControls extends PluginUIComponent<{}, { tab: LeftPanelTab
         return <div className='msp-left-panel-controls'>
             <div className='msp-left-panel-controls-buttons'>
                 {/* <IconButton svg={HomeOutlined} toggleState={tab === 'root'} transparent onClick={() => this.set('root')} title='Home' /> */}
-                {/* <DataIcon set={this.set} /> */}
+                <DataIcon set={this.set} />
                 {/* <IconButton svg={SaveOutlined} toggleState={tab === 'states'} transparent onClick={() => this.set('states')} title='Plugin State' /> */}
                 <IconButton svg={HelpOutlineSvg} toggleState={tab === 'help'} transparent onClick={() => this.set('help')} title='Help' />
                 {customState && customState.initParams && customState.initParams.superposition && <IconButton svg={WavesIconSvg} toggleState={tab === 'segments'} transparent onClick={() => this.set('segments')} title='Superpose segments' />}
@@ -97,30 +97,30 @@ export class LeftPanelControls extends PluginUIComponent<{}, { tab: LeftPanelTab
     }
 }
 
-// class DataIcon extends PluginUIComponent<{ set: (tab: LeftPanelTabName) => void }, { changed: boolean }> {
-//     state = { changed: false };
+class DataIcon extends PluginUIComponent<{ set: (tab: LeftPanelTabName) => void }, { changed: boolean }> {
+    state = { changed: false };
 
-//     get tab() {
-//         return this.plugin.behaviors.layout.leftPanelTabName.value;
-//     }
+    get tab() {
+        return this.plugin.behaviors.layout.leftPanelTabName.value;
+    }
 
-//     componentDidMount() {
-//         this.subscribe(this.plugin.behaviors.layout.leftPanelTabName, tab => {
-//             if (this.tab === 'data') this.setState({ changed: false });
-//             else this.forceUpdate();
-//         });
+    componentDidMount() {
+        this.subscribe(this.plugin.behaviors.layout.leftPanelTabName, tab => {
+            if (this.tab === 'data') this.setState({ changed: false });
+            else this.forceUpdate();
+        });
 
-//         this.subscribe(this.plugin.state.data.events.changed, state => {
-//             if (this.tab !== 'data') this.setState({ changed: true });
-//         });
-//     }
+        this.subscribe(this.plugin.state.data.events.changed, state => {
+            if (this.tab !== 'data') this.setState({ changed: true });
+        });
+    }
 
-//     render() {
-//         return <IconButton
-//             svg={AccountTreeOutlinedSvg} toggleState={this.tab === 'data'} transparent onClick={() => this.props.set('data')} title='State Tree'
-//             style={{ position: 'relative' }} extraContent={this.state.changed ? <div className='msp-left-panel-controls-button-data-dirty' /> : void 0} />;
-//     }
-// }
+    render() {
+        return <IconButton
+            svg={AccountTreeOutlinedSvg} toggleState={this.tab === 'data'} transparent onClick={() => this.props.set('data')} title='State Tree'
+            style={{ position: 'relative' }} extraContent={this.state.changed ? <div className='msp-left-panel-controls-button-data-dirty' /> : void 0} />;
+    }
+}
 
 class FullSettings extends PluginUIComponent {
     private setSettings = (p: { param: PD.Base<any>, name: string, value: any }) => {


### PR DESCRIPTION
Implementation:

- The state tree (DataIcon) was disabled (not sure why). Simply by uncommenting some code, it worked again. Even though we may not finally show the state tree for final users, it's a very valuable feature for debugging.
- `pdbePlugin.visual` provides some basic and opinionated helpers to update the plugin. I've added a couple of helpers Strictly, we could write them in our app (the plugin exposes all the internals), and that would make development easier, but it's cleaner this way.